### PR TITLE
Android 13: SDK v33 compatibility build 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,15 +8,15 @@ repositories {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 32
+    buildToolsVersion '32.0.0'
 
     defaultConfig {
         applicationId "ru.orangesoftware.financisto"
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 32
         versionCode 122
-        versionName "1.8.3"
+        versionName "sh-fork-1.8.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
         javaCompileOptions {
@@ -81,12 +81,12 @@ def AAVersion = '4.6.0'
 
 dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    implementation "com.google.android.gms:play-services-base:11.0.2"
-    implementation "com.google.android.gms:play-services-drive:11.0.2"
-    implementation "com.google.android.gms:play-services-plus:11.0.2"
+    implementation "com.google.android.gms:play-services-base:18.2.0"
+    implementation "com.google.android.gms:play-services-drive:17.0.0"
+    implementation "com.google.android.gms:play-services-plus:17.0.0"
 
     annotationProcessor "org.androidannotations:androidannotations:$AAVersion"
     implementation "org.androidannotations:androidannotations-api:$AAVersion"
@@ -110,6 +110,6 @@ dependencies {
     implementation fileTree(include: '**/*.jar', dir: 'libs')
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'androidx.test:core:1.2.0'
+    testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'org.robolectric:robolectric:4.2.1'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,13 +8,13 @@ repositories {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 32
-    buildToolsVersion '32.0.0'
+    compileSdkVersion 33
+    buildToolsVersion '33.0.2'
 
     defaultConfig {
         applicationId "ru.orangesoftware.financisto"
-        minSdkVersion 19
-        targetSdkVersion 32
+        minSdkVersion 32
+        targetSdkVersion 33
         versionCode 122
         versionName "sh-fork-1.8.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,7 +40,6 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
@@ -48,7 +47,6 @@
 
     <application
         android:name=".app.FinancistoApp_"
-        android:allowBackup="true"
         android:description="@string/app_description"
         android:hardwareAccelerated="true"
         android:icon="@drawable/icon"
@@ -150,7 +148,6 @@
         <activity
             android:name=".activity.MainActivity"
             android:configChanges="orientation|screenSize|keyboardHidden"
-            android:label="@string/app_name"
             android:taskAffinity=".MainActivity"
             android:exported="true">
             <intent-filter>
@@ -193,7 +190,6 @@
 
         <activity
             android:name=".activity.PinActivity"
-            android:label="@string/app_name"
             android:launchMode="singleTop" />
 
         <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,7 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
-    <uses-permission android:name="android.permission.USE_FINGERPRINT" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
     <application
         android:name=".app.FinancistoApp_"
@@ -57,7 +57,8 @@
 
         <receiver
             android:name=".activity.AccountWidget"
-            android:label="@string/widget_2x1">
+            android:label="@string/widget_2x1"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
                 <action android:name=".UPDATE_WIDGET" />
@@ -69,7 +70,8 @@
 
         <receiver
             android:name=".activity.AccountWidget3x1"
-            android:label="@string/widget_3x1">
+            android:label="@string/widget_3x1"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
                 <action android:name=".UPDATE_WIDGET" />
@@ -81,7 +83,8 @@
 
         <receiver
             android:name=".activity.AccountWidget4x1"
-            android:label="@string/widget_4x1">
+            android:label="@string/widget_4x1"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
                 <action android:name=".UPDATE_WIDGET" />
@@ -91,7 +94,8 @@
                 android:resource="@xml/widget_4x1" />
         </receiver>
 
-        <receiver android:name=".activity.ScheduledAlarmReceiver">
+        <receiver android:name=".activity.ScheduledAlarmReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name=".SCHEDULED_ALARM" />
                 <action android:name=".SCHEDULED_BACKUP" />
@@ -99,7 +103,8 @@
             </intent-filter>
         </receiver>
 
-        <receiver android:name=".activity.PackageReplaceReceiver">
+        <receiver android:name=".activity.PackageReplaceReceiver"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.PACKAGE_REPLACED" />
                 <data
@@ -146,7 +151,8 @@
             android:name=".activity.MainActivity"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:label="@string/app_name"
-            android:taskAffinity=".MainActivity">
+            android:taskAffinity=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -159,7 +165,8 @@
             android:icon="@drawable/icon_transaction"
             android:label="@string/transaction"
             android:taskAffinity=".TransactionActivity"
-            android:windowSoftInputMode="stateAlwaysHidden|adjustResize">
+            android:windowSoftInputMode="stateAlwaysHidden|adjustResize"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name=".NEW_TRANSACTION" />
@@ -174,7 +181,8 @@
             android:icon="@drawable/icon_transfer"
             android:label="@string/transfer"
             android:taskAffinity=".TransferActivity"
-            android:windowSoftInputMode="stateAlwaysHidden|adjustResize">
+            android:windowSoftInputMode="stateAlwaysHidden|adjustResize"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <action android:name=".NEW_TRANSFER" />
@@ -460,7 +468,8 @@
         <activity
             android:name="com.dropbox.core.android.AuthActivity"
             android:configChanges="orientation|keyboard"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:exported="true">
             <intent-filter>
 
                 <!-- Change this to be db- followed by your app key -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         android:required="false" />
 
     <!-- Custom permissions -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
 
     <!-- System permissions -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,13 @@
     <uses-permission android:name="android.permission.RECEIVE_SMS" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="resource/folder" />
+        </intent>
+    </queries>
+
     <application
         android:name=".app.FinancistoApp_"
         android:description="@string/app_description"

--- a/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListActivity.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListActivity.java
@@ -11,6 +11,7 @@
  ******************************************************************************/
 package ru.orangesoftware.financisto.activity;
 
+import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ListActivity;
 import android.app.ProgressDialog;
@@ -18,7 +19,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.net.Uri;
-import android.util.Log;
 import android.view.View;
 import android.widget.ListView;
 import android.widget.Toast;
@@ -26,8 +26,6 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.common.api.Status;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.List;
 import org.androidannotations.annotations.AfterViews;
 import org.androidannotations.annotations.Bean;
@@ -37,9 +35,8 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import ru.orangesoftware.financisto.R;
 import ru.orangesoftware.financisto.adapter.SummaryEntityListAdapter;
-import ru.orangesoftware.financisto.backup.DatabaseImport;
 import ru.orangesoftware.financisto.bus.GreenRobotBus;
-import ru.orangesoftware.financisto.db.DatabaseAdapter;
+import ru.orangesoftware.financisto.export.BackupExportTask;
 import ru.orangesoftware.financisto.export.BackupImportTask;
 import ru.orangesoftware.financisto.export.csv.CsvExportOptions;
 import ru.orangesoftware.financisto.export.csv.CsvImportOptions;
@@ -127,10 +124,19 @@ public class MenuListActivity extends ListActivity {
     @OnActivityResult(MenuListItem.ACTIVITY_CHOOSE_BACKUP_FILE_FOR_RESTORE)
     public void onRestoreFromBackup(int resultCode, Intent data) {
         if (data != null) {
-            // todo: use this file to restore the database
             Uri backupFileUri = data.getData();
             ProgressDialog d = ProgressDialog.show(this, null, this.getString(R.string.restore_database_inprogress), true);
                             new BackupImportTask(this, d).execute(backupFileUri);
+        }
+    }
+
+    @OnActivityResult(MenuListItem.ACTIVITY_CHOOSE_BACKUP_LOCATION)
+    public void onChooseBackupLocation(int resultCode, Intent data) {
+        if(resultCode == Activity.RESULT_OK && data != null) {
+            Uri backupFileUri = data.getData();
+
+            ProgressDialog d = ProgressDialog.show(this, null, getString(R.string.backup_database_inprogress), true);
+            new BackupExportTask(this, d, true).execute(backupFileUri);
         }
     }
 

--- a/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListActivity.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListActivity.java
@@ -17,12 +17,17 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
+import android.net.Uri;
+import android.util.Log;
 import android.view.View;
 import android.widget.ListView;
 import android.widget.Toast;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.common.api.Status;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.List;
 import org.androidannotations.annotations.AfterViews;
 import org.androidannotations.annotations.Bean;
@@ -32,7 +37,10 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 import ru.orangesoftware.financisto.R;
 import ru.orangesoftware.financisto.adapter.SummaryEntityListAdapter;
+import ru.orangesoftware.financisto.backup.DatabaseImport;
 import ru.orangesoftware.financisto.bus.GreenRobotBus;
+import ru.orangesoftware.financisto.db.DatabaseAdapter;
+import ru.orangesoftware.financisto.export.BackupImportTask;
 import ru.orangesoftware.financisto.export.csv.CsvExportOptions;
 import ru.orangesoftware.financisto.export.csv.CsvImportOptions;
 import ru.orangesoftware.financisto.export.drive.DoDriveBackup;
@@ -55,7 +63,6 @@ import static ru.orangesoftware.financisto.service.DailyAutoBackupScheduler.sche
 import ru.orangesoftware.financisto.utils.PinProtection;
 
 import ru.orangesoftware.financisto.utils.MyPreferences;
-import ru.orangesoftware.financisto.utils.PinProtection;
 
 @EActivity(R.layout.activity_menu_list)
 public class MenuListActivity extends ListActivity {
@@ -115,6 +122,16 @@ public class MenuListActivity extends ListActivity {
     @OnActivityResult(MenuListItem.ACTIVITY_CHANGE_PREFERENCES)
     public void onChangePreferences() {
         scheduleNextAutoBackup(this);
+    }
+
+    @OnActivityResult(MenuListItem.ACTIVITY_CHOOSE_BACKUP_FILE_FOR_RESTORE)
+    public void onRestoreFromBackup(int resultCode, Intent data) {
+        if (data != null) {
+            // todo: use this file to restore the database
+            Uri backupFileUri = data.getData();
+            ProgressDialog d = ProgressDialog.show(this, null, this.getString(R.string.restore_database_inprogress), true);
+                            new BackupImportTask(this, d).execute(backupFileUri);
+        }
     }
 
     @Override

--- a/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListItem.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListItem.java
@@ -32,6 +32,8 @@ import ru.orangesoftware.financisto.export.qif.QifImportOptions;
 import ru.orangesoftware.financisto.export.qif.QifImportTask;
 import ru.orangesoftware.financisto.utils.EntityEnum;
 import ru.orangesoftware.financisto.utils.EnumUtils;
+
+import static ru.orangesoftware.financisto.export.Export.BACKUP_MIME_TYPE;
 import static ru.orangesoftware.financisto.utils.EnumUtils.showPickOneDialog;
 import ru.orangesoftware.financisto.utils.ExecutableEntityEnum;
 import ru.orangesoftware.financisto.utils.IntegrityFix;
@@ -77,25 +79,10 @@ public enum MenuListItem implements SummaryEntityEnum {
     MENU_RESTORE(R.string.restore_database, R.string.restore_database_summary, R.drawable.actionbar_db_restore) {
         @Override
         public void call(final Activity activity) {
-            if (isRequestingPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                return;
-            }
-            final String[] backupFiles = Backup.listBackups(activity);
-            final String[] selectedBackupFile = new String[1];
-            new AlertDialog.Builder(activity)
-                    .setTitle(R.string.restore_database)
-                    .setPositiveButton(R.string.restore, (dialog, which) -> {
-                        if (selectedBackupFile[0] != null) {
-                            ProgressDialog d = ProgressDialog.show(activity, null, activity.getString(R.string.restore_database_inprogress), true);
-                            new BackupImportTask(activity, d).execute(selectedBackupFile);
-                        }
-                    })
-                    .setSingleChoiceItems(backupFiles, -1, (dialog, which) -> {
-                        if (backupFiles != null && which >= 0 && which < backupFiles.length) {
-                            selectedBackupFile[0] = backupFiles[which];
-                        }
-                    })
-                    .show();
+            Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+            intent.setType("*/*"); // allow any file type to be selected
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            activity.startActivityForResult(intent, ACTIVITY_CHOOSE_BACKUP_FILE_FOR_RESTORE);
         }
     },
     GOOGLE_DRIVE_BACKUP(R.string.backup_database_online_google_drive, R.string.backup_database_online_google_drive_summary, R.drawable.actionbar_google_drive) {
@@ -152,7 +139,7 @@ public enum MenuListItem implements SummaryEntityEnum {
                 intent.setType("text/plain");
                 activity.startActivity(Intent.createChooser(intent, activity.getString(R.string.backup_database_to_title)));
             });
-            t.execute((String[]) null);
+            t.execute((Uri[]) null);
         }
     },
     MENU_IMPORT_EXPORT(R.string.import_export, R.string.import_export_summary, R.drawable.actionbar_export) {
@@ -245,6 +232,9 @@ public enum MenuListItem implements SummaryEntityEnum {
     public static final int ACTIVITY_CSV_IMPORT = 4;
     public static final int ACTIVITY_QIF_IMPORT = 5;
     public static final int ACTIVITY_CHANGE_PREFERENCES = 6;
+
+    public static final int ACTIVITY_CHOOSE_BACKUP_FILE_FOR_RESTORE = 7;
+    public static final int ACTIVITY_RESTORE_FROM_BACKUP = 8;
 
     public abstract void call(Activity activity);
 

--- a/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListItem.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListItem.java
@@ -16,11 +16,9 @@ import ru.orangesoftware.financisto.BuildConfig;
 import ru.orangesoftware.financisto.R;
 import static ru.orangesoftware.financisto.activity.RequestPermission.isRequestingPermission;
 import static ru.orangesoftware.financisto.activity.RequestPermission.isRequestingPermissions;
-import ru.orangesoftware.financisto.backup.Backup;
 import ru.orangesoftware.financisto.bus.GreenRobotBus_;
 import ru.orangesoftware.financisto.db.DatabaseAdapter;
 import ru.orangesoftware.financisto.export.BackupExportTask;
-import ru.orangesoftware.financisto.export.BackupImportTask;
 import ru.orangesoftware.financisto.export.Export;
 import ru.orangesoftware.financisto.export.csv.CsvExportOptions;
 import ru.orangesoftware.financisto.export.csv.CsvExportTask;
@@ -69,9 +67,6 @@ public enum MenuListItem implements SummaryEntityEnum {
     MENU_BACKUP(R.string.backup_database, R.string.backup_database_summary, R.drawable.actionbar_db_backup) {
         @Override
         public void call(Activity activity) {
-            if (isRequestingPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                return;
-            }
             ProgressDialog d = ProgressDialog.show(activity, null, activity.getString(R.string.backup_database_inprogress), true);
             new BackupExportTask(activity, d, true).execute();
         }

--- a/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListItem.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/MenuListItem.java
@@ -16,6 +16,8 @@ import ru.orangesoftware.financisto.BuildConfig;
 import ru.orangesoftware.financisto.R;
 import static ru.orangesoftware.financisto.activity.RequestPermission.isRequestingPermission;
 import static ru.orangesoftware.financisto.activity.RequestPermission.isRequestingPermissions;
+
+import ru.orangesoftware.financisto.backup.DatabaseExport;
 import ru.orangesoftware.financisto.bus.GreenRobotBus_;
 import ru.orangesoftware.financisto.db.DatabaseAdapter;
 import ru.orangesoftware.financisto.export.BackupExportTask;
@@ -31,7 +33,6 @@ import ru.orangesoftware.financisto.export.qif.QifImportTask;
 import ru.orangesoftware.financisto.utils.EntityEnum;
 import ru.orangesoftware.financisto.utils.EnumUtils;
 
-import static ru.orangesoftware.financisto.export.Export.BACKUP_MIME_TYPE;
 import static ru.orangesoftware.financisto.utils.EnumUtils.showPickOneDialog;
 import ru.orangesoftware.financisto.utils.ExecutableEntityEnum;
 import ru.orangesoftware.financisto.utils.IntegrityFix;
@@ -67,8 +68,18 @@ public enum MenuListItem implements SummaryEntityEnum {
     MENU_BACKUP(R.string.backup_database, R.string.backup_database_summary, R.drawable.actionbar_db_backup) {
         @Override
         public void call(Activity activity) {
-            ProgressDialog d = ProgressDialog.show(activity, null, activity.getString(R.string.backup_database_inprogress), true);
-            new BackupExportTask(activity, d, true).execute();
+
+            Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("application/gzip");
+
+            DatabaseAdapter db = new DatabaseAdapter(activity);
+            db.open();
+            DatabaseExport export = new DatabaseExport(activity, db.db(), true);
+
+            intent.putExtra(Intent.EXTRA_TITLE, export.generateFilename());
+
+            activity.startActivityForResult(intent, ACTIVITY_CHOOSE_BACKUP_LOCATION);
         }
     },
     MENU_RESTORE(R.string.restore_database, R.string.restore_database_summary, R.drawable.actionbar_db_restore) {
@@ -230,6 +241,8 @@ public enum MenuListItem implements SummaryEntityEnum {
 
     public static final int ACTIVITY_CHOOSE_BACKUP_FILE_FOR_RESTORE = 7;
     public static final int ACTIVITY_RESTORE_FROM_BACKUP = 8;
+
+    public static final int ACTIVITY_CHOOSE_BACKUP_LOCATION = 9;
 
     public abstract void call(Activity activity);
 

--- a/app/src/main/java/ru/orangesoftware/financisto/activity/PreferencesActivity.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/activity/PreferencesActivity.java
@@ -18,6 +18,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.Intent.ShortcutIconResource;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
@@ -78,9 +79,9 @@ public class PreferencesActivity extends PreferenceActivity {
         });
         Preference pDatabaseBackupFolder = preferenceScreen.findPreference("database_backup_folder");
         pDatabaseBackupFolder.setOnPreferenceClickListener(arg0 -> {
-            if (isRequestingPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-                return false;
-            }
+//            if (isRequestingPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+//                return false;
+//            }
             selectDatabaseBackupFolder();
             return true;
         });

--- a/app/src/main/java/ru/orangesoftware/financisto/backup/DatabaseImport.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/backup/DatabaseImport.java
@@ -13,6 +13,7 @@ package ru.orangesoftware.financisto.backup;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.net.Uri;
 import android.util.Log;
 
 import com.dropbox.core.util.IOUtil;
@@ -73,6 +74,11 @@ public class DatabaseImport extends FullDatabaseImport {
         super(context, dbAdapter);
         this.schemaEvolution = new DatabaseSchemaEvolution(context, Database.DATABASE_NAME, null, Database.DATABASE_VERSION);
         this.backupStream = backupStream;
+    }
+
+    public static DatabaseImport createFromFileBackupUri(Context context, DatabaseAdapter dbAdapter, Uri backupFileUril) throws FileNotFoundException {
+        FileInputStream inputStream = (FileInputStream) context.getContentResolver().openInputStream(backupFileUril);
+        return new DatabaseImport(context, dbAdapter, inputStream);
     }
 
     @Override

--- a/app/src/main/java/ru/orangesoftware/financisto/export/BackupExportTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/BackupExportTask.java
@@ -5,6 +5,8 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.net.Uri;
 
+import java.io.FileOutputStream;
+
 import ru.orangesoftware.financisto.backup.DatabaseExport;
 import ru.orangesoftware.financisto.db.DatabaseAdapter;
 
@@ -21,8 +23,13 @@ public class BackupExportTask extends ImportExportAsyncTask {
 	
 	@Override
 	protected Object work(Context context, DatabaseAdapter db, Uri...params) throws Exception {
+		backupFileName = params[0].getLastPathSegment();
+
+		FileOutputStream outputStream = (FileOutputStream) context.getContentResolver().openOutputStream(params[0]);
 		DatabaseExport export = new DatabaseExport(context, db.db(), true);
-        backupFileName = export.export();
+        export.export(outputStream);
+
+		// todo: this needs to be fixed to use a Uri instead of filename
         if (uploadOnline) {
             doUploadToDropbox(context, backupFileName);
 			doUploadToGoogleDrive(context, backupFileName);

--- a/app/src/main/java/ru/orangesoftware/financisto/export/BackupExportTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/BackupExportTask.java
@@ -3,6 +3,8 @@ package ru.orangesoftware.financisto.export;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.net.Uri;
+
 import ru.orangesoftware.financisto.backup.DatabaseExport;
 import ru.orangesoftware.financisto.db.DatabaseAdapter;
 
@@ -18,7 +20,7 @@ public class BackupExportTask extends ImportExportAsyncTask {
 	}
 	
 	@Override
-	protected Object work(Context context, DatabaseAdapter db, String...params) throws Exception {
+	protected Object work(Context context, DatabaseAdapter db, Uri...params) throws Exception {
 		DatabaseExport export = new DatabaseExport(context, db.db(), true);
         backupFileName = export.export();
         if (uploadOnline) {

--- a/app/src/main/java/ru/orangesoftware/financisto/export/BackupImportTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/BackupImportTask.java
@@ -12,6 +12,7 @@ import android.app.Activity;
 import android.app.ProgressDialog;
 import android.app.TabActivity;
 import android.content.Context;
+import android.net.Uri;
 import android.widget.TabHost;
 
 import ru.orangesoftware.financisto.R;
@@ -31,8 +32,8 @@ public class BackupImportTask extends ImportExportAsyncTask {
     }
 
     @Override
-    protected Object work(Context context, DatabaseAdapter db, String... params) throws Exception {
-        DatabaseImport.createFromFileBackup(context, db, params[0]).importDatabase();
+    protected Object work(Context context, DatabaseAdapter db, Uri... params) throws Exception {
+        DatabaseImport.createFromFileBackupUri(context, db, params[0]).importDatabase();
         return true;
     }
 

--- a/app/src/main/java/ru/orangesoftware/financisto/export/Export.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/Export.java
@@ -14,6 +14,7 @@ import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.os.Environment;
+import android.util.Log;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedWriter;
@@ -23,16 +24,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.zip.GZIPOutputStream;
 
-import ru.orangesoftware.financisto.R;
-import ru.orangesoftware.financisto.activity.RequestPermission;
 import ru.orangesoftware.financisto.export.drive.GoogleDriveClient;
 import ru.orangesoftware.financisto.export.drive.GoogleDriveClient_;
 import ru.orangesoftware.financisto.export.dropbox.Dropbox;
-import ru.orangesoftware.financisto.utils.MyPreferences;
 
 public abstract class Export {
 
@@ -48,9 +47,6 @@ public abstract class Export {
     }
 
     public String export() throws Exception {
-        if (!RequestPermission.checkPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-            throw new ImportExportException(R.string.request_permissions_storage_not_granted);
-        }
         File path = getBackupFolder(context);
         String fileName = generateFilename();
         File file = new File(path, fileName);
@@ -65,6 +61,8 @@ public abstract class Export {
             outputStream.flush();
             outputStream.close();
         }
+
+        Log.i("backup", "database backed up to this file: " + fileName);
         return fileName;
     }
 
@@ -102,14 +100,9 @@ public abstract class Export {
     protected abstract String getExtension();
 
     public static File getBackupFolder(Context context) {
-        String path = MyPreferences.getDatabaseBackupFolder(context);
-        File file = new File(path);
+        File file = Paths.get(context.getFilesDir().getAbsolutePath(), "backup").toFile();
         file.mkdirs();
-        if (file.isDirectory() && file.canWrite()) {
-            return file;
-        }
-        file = Export.DEFAULT_EXPORT_PATH;
-        file.mkdirs();
+
         return file;
     }
 

--- a/app/src/main/java/ru/orangesoftware/financisto/export/Export.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/Export.java
@@ -51,19 +51,24 @@ public abstract class Export {
         String fileName = generateFilename();
         File file = new File(path, fileName);
         FileOutputStream outputStream = new FileOutputStream(file);
-        try {
-            if (useGzip) {
-                export(new GZIPOutputStream(outputStream));
-            } else {
-                export(outputStream);
-            }
-        } finally {
-            outputStream.flush();
-            outputStream.close();
-        }
+
+        export(outputStream);
 
         Log.i("backup", "database backed up to this file: " + fileName);
         return fileName;
+    }
+
+    public void export(FileOutputStream fileOutputStream) throws Exception {
+        try {
+            if (useGzip) {
+                export(new GZIPOutputStream(fileOutputStream));
+            } else {
+                export(fileOutputStream);
+            }
+        } finally {
+            fileOutputStream.flush();
+            fileOutputStream.close();
+        }
     }
 
     protected void export(OutputStream outputStream) throws Exception {

--- a/app/src/main/java/ru/orangesoftware/financisto/export/ImportExportAsyncTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/ImportExportAsyncTask.java
@@ -14,6 +14,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.util.Log;
 import android.widget.Toast;
@@ -27,7 +28,7 @@ import ru.orangesoftware.financisto.utils.MyPreferences;
 import static ru.orangesoftware.financisto.export.Export.uploadBackupFileToDropbox;
 import static ru.orangesoftware.financisto.export.Export.uploadBackupFileToGoogleDrive;
 
-public abstract class ImportExportAsyncTask extends AsyncTask<String, String, Object> {
+public abstract class ImportExportAsyncTask extends AsyncTask<Uri, String, Object> {
 
     protected final Activity context;
     protected final ProgressDialog dialog;
@@ -49,7 +50,7 @@ public abstract class ImportExportAsyncTask extends AsyncTask<String, String, Ob
     }
 
     @Override
-    protected Object doInBackground(String... params) {
+    protected Object doInBackground(Uri... params) {
         DatabaseAdapter db = new DatabaseAdapter(context);
         db.open();
         try {
@@ -62,7 +63,7 @@ public abstract class ImportExportAsyncTask extends AsyncTask<String, String, Ob
         }
     }
 
-    protected abstract Object work(Context context, DatabaseAdapter db, String... params) throws Exception;
+    protected abstract Object work(Context context, DatabaseAdapter db, Uri... params) throws Exception;
 
     protected abstract String getSuccessMessage(Object result);
 

--- a/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvExportTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvExportTask.java
@@ -3,6 +3,8 @@ package ru.orangesoftware.financisto.export.csv;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.net.Uri;
+
 import ru.orangesoftware.financisto.db.DatabaseAdapter;
 import ru.orangesoftware.financisto.export.ImportExportAsyncTask;
 
@@ -16,7 +18,7 @@ public class CsvExportTask extends ImportExportAsyncTask {
 	}
 	
 	@Override
-	protected Object work(Context context, DatabaseAdapter db, String...params) throws Exception {
+	protected Object work(Context context, DatabaseAdapter db, Uri...params) throws Exception {
 		CsvExport export = new CsvExport(context, db, options);
         String backupFileName = export.export();
         if (options.uploadToDropbox) {

--- a/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvImportTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/csv/CsvImportTask.java
@@ -11,6 +11,7 @@ package ru.orangesoftware.financisto.export.csv;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.net.Uri;
 import android.util.Log;
 
 import ru.orangesoftware.financisto.R;
@@ -34,7 +35,7 @@ public class CsvImportTask extends ImportExportAsyncTask {
     }
 
     @Override
-    protected Object work(Context context, DatabaseAdapter db, String... params) throws Exception {
+    protected Object work(Context context, DatabaseAdapter db, Uri... params) throws Exception {
         try {
             CsvImport csvimport = new CsvImport(db, options);
             csvimport.setProgressListener(new ProgressListener() {

--- a/app/src/main/java/ru/orangesoftware/financisto/export/drive/GoogleDriveClient.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/drive/GoogleDriveClient.java
@@ -75,20 +75,23 @@ public class GoogleDriveClient {
     }
 
     private ConnectionResult connect() throws ImportExportException {
-        if (googleApiClient == null) {
-            String googleDriveAccount = MyPreferences.getGoogleDriveAccount(context);
-            if (googleDriveAccount == null) {
-                throw new ImportExportException(R.string.google_drive_account_required);
-            }
-            googleApiClient = new GoogleApiClient.Builder(context)
-                    .addApi(Drive.API)
-                    .addScope(Drive.SCOPE_FILE)
-                    .setAccountName(googleDriveAccount)
-                    //.addConnectionCallbacks(this)
-                    //.addOnConnectionFailedListener(this)
-                    .build();
-        }
-        return googleApiClient.blockingConnect(1, TimeUnit.MINUTES);
+//        if (googleApiClient == null) {
+//            String googleDriveAccount = MyPreferences.getGoogleDriveAccount(context);
+//            if (googleDriveAccount == null) {
+//                throw new ImportExportException(R.string.google_drive_account_required);
+//            }
+//            googleApiClient = new GoogleApiClient.Builder(context)
+//                    .addApi(Drive.API)
+//                    .addScope(Drive.SCOPE_FILE)
+//                    .setAccountName(googleDriveAccount)
+//                    //.addConnectionCallbacks(this)
+//                    //.addOnConnectionFailedListener(this)
+//                    .build();
+//        }
+//        return googleApiClient.blockingConnect(1, TimeUnit.MINUTES);
+
+        // todo: the older apis have been deprecated. need to migrate to google drive v3 apis. disabled until then
+        throw new ImportExportException(R.string.google_drive_disabled);
     }
 
     public void disconnect() {
@@ -101,21 +104,23 @@ public class GoogleDriveClient {
     public void doBackup(DoDriveBackup event) {
         DatabaseExport export = new DatabaseExport(context, db.db(), true);
         try {
-            String targetFolder = getDriveFolderName();
-            ConnectionResult connectionResult = connect();
-            if (connectionResult.isSuccess()) {
-                DriveFolder folder = getDriveFolder(targetFolder);
-                String fileName = export.generateFilename();
-                byte[] bytes = export.generateBackupBytes();
-                Status status = createFile(folder, fileName, bytes);
-                if (status.isSuccess()) {
-                    handleSuccess(fileName);
-                } else {
-                    handleFailure(status);
-                }
-            } else {
-                handleConnectionResult(connectionResult);
-            }
+//            String targetFolder = getDriveFolderName();
+//            ConnectionResult connectionResult = connect();
+//            if (connectionResult.isSuccess()) {
+//                DriveFolder folder = getDriveFolder(targetFolder);
+//                String fileName = export.generateFilename();
+//                byte[] bytes = export.generateBackupBytes();
+//                Status status = createFile(folder, fileName, bytes);
+//                if (status.isSuccess()) {
+//                    handleSuccess(fileName);
+//                } else {
+//                    handleFailure(status);
+//                }
+//            } else {
+//                handleConnectionResult(connectionResult);
+//            }
+            throw new ImportExportException(R.string.google_drive_disabled);
+
         } catch (Exception e) {
             handleError(e);
         }
@@ -124,26 +129,28 @@ public class GoogleDriveClient {
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     public void listFiles(DoDriveListFiles event) {
         try {
-            String targetFolder = getDriveFolderName();
-            ConnectionResult connectionResult = connect();
-            if (connectionResult.isSuccess()) {
-                DriveFolder folder = getDriveFolder(targetFolder);
-                Query query = new Query.Builder()
-                        .addFilter(Filters.and(
-                                Filters.eq(SearchableField.MIME_TYPE, Export.BACKUP_MIME_TYPE),
-                                Filters.eq(SearchableField.TRASHED, false)
-                        ))
-                        .build();
-                DriveApi.MetadataBufferResult metadataBufferResult = folder.queryChildren(googleApiClient, query).await();
-                if (metadataBufferResult.getStatus().isSuccess()) {
-                    List<DriveFileInfo> driveFiles = fetchFiles(metadataBufferResult);
-                    handleSuccess(driveFiles);
-                } else {
-                    handleFailure(metadataBufferResult.getStatus());
-                }
-            } else {
-                handleConnectionResult(connectionResult);
-            }
+//            String targetFolder = getDriveFolderName();
+//            ConnectionResult connectionResult = connect();
+//            if (connectionResult.isSuccess()) {
+//                DriveFolder folder = getDriveFolder(targetFolder);
+//                Query query = new Query.Builder()
+//                        .addFilter(Filters.and(
+//                                Filters.eq(SearchableField.MIME_TYPE, Export.BACKUP_MIME_TYPE),
+//                                Filters.eq(SearchableField.TRASHED, false)
+//                        ))
+//                        .build();
+//                DriveApi.MetadataBufferResult metadataBufferResult = folder.queryChildren(googleApiClient, query).await();
+//                if (metadataBufferResult.getStatus().isSuccess()) {
+//                    List<DriveFileInfo> driveFiles = fetchFiles(metadataBufferResult);
+//                    handleSuccess(driveFiles);
+//                } else {
+//                    handleFailure(metadataBufferResult.getStatus());
+//                }
+//            } else {
+//                handleConnectionResult(connectionResult);
+//            }
+            throw new ImportExportException(R.string.google_drive_disabled);
+
         } catch (Exception e) {
             handleError(e);
         }
@@ -152,24 +159,26 @@ public class GoogleDriveClient {
     @Subscribe(threadMode = ThreadMode.BACKGROUND)
     public void doRestore(DoDriveRestore event) {
         try {
-            ConnectionResult connectionResult = connect();
-            if (connectionResult.isSuccess()) {
-                DriveFile file = Drive.DriveApi.getFile(googleApiClient, event.selectedDriveFile.driveId);
-                DriveApi.DriveContentsResult contentsResult = file.open(googleApiClient, DriveFile.MODE_READ_ONLY, null).await();
-                if (contentsResult.getStatus().isSuccess()) {
-                    DriveContents contents = contentsResult.getDriveContents();
-                    try {
-                        DatabaseImport.createFromGoogleDriveBackup(context, db, contents).importDatabase();
-                        bus.post(new DriveRestoreSuccess());
-                    } finally {
-                        contents.discard(googleApiClient);
-                    }
-                } else {
-                    handleFailure(contentsResult.getStatus());
-                }
-            } else {
-                handleConnectionResult(connectionResult);
-            }
+//            ConnectionResult connectionResult = connect();
+//            if (connectionResult.isSuccess()) {
+//                DriveFile file = Drive.DriveApi.getFile(googleApiClient, event.selectedDriveFile.driveId);
+//                DriveApi.DriveContentsResult contentsResult = file.open(googleApiClient, DriveFile.MODE_READ_ONLY, null).await();
+//                if (contentsResult.getStatus().isSuccess()) {
+//                    DriveContents contents = contentsResult.getDriveContents();
+//                    try {
+//                        DatabaseImport.createFromGoogleDriveBackup(context, db, contents).importDatabase();
+//                        bus.post(new DriveRestoreSuccess());
+//                    } finally {
+//                        contents.discard(googleApiClient);
+//                    }
+//                } else {
+//                    handleFailure(contentsResult.getStatus());
+//                }
+//            } else {
+//                handleConnectionResult(connectionResult);
+//            }
+            throw new ImportExportException(R.string.google_drive_disabled);
+
         } catch (Exception e) {
             handleError(e);
         }
@@ -177,94 +186,102 @@ public class GoogleDriveClient {
 
     private List<DriveFileInfo> fetchFiles(DriveApi.MetadataBufferResult metadataBufferResult) {
         List<DriveFileInfo> files = new ArrayList<DriveFileInfo>();
-        MetadataBuffer metadataBuffer = metadataBufferResult.getMetadataBuffer();
-        if (metadataBuffer == null) return files;
-        try {
-            for (Metadata metadata : metadataBuffer) {
-                if (metadata == null) continue;
-                String title = metadata.getTitle();
-                if (!title.endsWith(".backup")) continue;
-                files.add(new DriveFileInfo(metadata.getDriveId(), title, metadata.getCreatedDate()));
-            }
-        } finally {
-            metadataBuffer.close();
-        }
-        Collections.sort(files);
+//        MetadataBuffer metadataBuffer = metadataBufferResult.getMetadataBuffer();
+//        if (metadataBuffer == null) return files;
+//        try {
+//            for (Metadata metadata : metadataBuffer) {
+//                if (metadata == null) continue;
+//                String title = metadata.getTitle();
+//                if (!title.endsWith(".backup")) continue;
+//                files.add(new DriveFileInfo(metadata.getDriveId(), title, metadata.getCreatedDate()));
+//            }
+//        } finally {
+//            metadataBuffer.close();
+//        }
+//        Collections.sort(files);
         return files;
     }
 
     private String getDriveFolderName() throws ImportExportException {
-        String folder = MyPreferences.getBackupFolder(context);
-        // check the backup folder registered on preferences
-        if (folder == null || folder.equals("")) {
-            throw new ImportExportException(R.string.gdocs_folder_not_configured);
-        }
-        return folder;
+//        String folder = MyPreferences.getBackupFolder(context);
+//        // check the backup folder registered on preferences
+//        if (folder == null || folder.equals("")) {
+//            throw new ImportExportException(R.string.gdocs_folder_not_configured);
+//        }
+//        return folder;
+        throw new ImportExportException(R.string.google_drive_disabled);
+
     }
 
     private DriveFolder getDriveFolder(String targetFolder) throws IOException, ImportExportException {
-        DriveFolder folder = getOrCreateDriveFolder(targetFolder);
-        if (folder == null) {
-            throw new ImportExportException(R.string.gdocs_folder_not_found);
-        }
-        return folder;
+//        DriveFolder folder = getOrCreateDriveFolder(targetFolder);
+//        if (folder == null) {
+//            throw new ImportExportException(R.string.gdocs_folder_not_found);
+//        }
+//        return folder;
+        throw new ImportExportException(R.string.google_drive_disabled);
+
     }
 
     private DriveFolder getOrCreateDriveFolder(String targetFolder) throws IOException {
-        Query query = new Query.Builder().addFilter(Filters.and(
-                Filters.eq(SearchableField.TRASHED, false),
-                Filters.eq(SearchableField.TITLE, targetFolder),
-                Filters.eq(SearchableField.MIME_TYPE, "application/vnd.google-apps.folder")
-        )).build();
-        DriveApi.MetadataBufferResult result = Drive.DriveApi.query(googleApiClient, query).await();
-        if (result.getStatus().isSuccess()) {
-            DriveId driveId = fetchDriveId(result);
-            if (driveId != null) {
-                return Drive.DriveApi.getFolder(googleApiClient, driveId);
-            }
-        }
-        return createDriveFolder(targetFolder);
+//        Query query = new Query.Builder().addFilter(Filters.and(
+//                Filters.eq(SearchableField.TRASHED, false),
+//                Filters.eq(SearchableField.TITLE, targetFolder),
+//                Filters.eq(SearchableField.MIME_TYPE, "application/vnd.google-apps.folder")
+//        )).build();
+//        DriveApi.MetadataBufferResult result = Drive.DriveApi.query(googleApiClient, query).await();
+//        if (result.getStatus().isSuccess()) {
+//            DriveId driveId = fetchDriveId(result);
+//            if (driveId != null) {
+//                return Drive.DriveApi.getFolder(googleApiClient, driveId);
+//            }
+//        }
+//        return createDriveFolder(targetFolder);
+        throw new IOException(String.valueOf(R.string.google_drive_disabled));
+
     }
 
     private DriveFolder createDriveFolder(String targetFolder) {
-        MetadataChangeSet changeSet = new MetadataChangeSet.Builder()
-                .setTitle(targetFolder).build();
-        DriveFolder.DriveFolderResult result = Drive.DriveApi.getRootFolder(googleApiClient).createFolder(googleApiClient, changeSet).await();
-        if (result.getStatus().isSuccess()) {
-            return result.getDriveFolder();
-        } else {
+//        MetadataChangeSet changeSet = new MetadataChangeSet.Builder()
+//                .setTitle(targetFolder).build();
+//        DriveFolder.DriveFolderResult result = Drive.DriveApi.getRootFolder(googleApiClient).createFolder(googleApiClient, changeSet).await();
+//        if (result.getStatus().isSuccess()) {
+//            return result.getDriveFolder();
+//        } else {
             return null;
-        }
+//        }
     }
 
     private DriveId fetchDriveId(DriveApi.MetadataBufferResult result) {
-        MetadataBuffer buffer = result.getMetadataBuffer();
-        try {
-            for (Metadata metadata : buffer) {
-                if (metadata == null) continue;
-                return metadata.getDriveId();
-            }
-        } finally {
-            buffer.close();
-        }
+//        MetadataBuffer buffer = result.getMetadataBuffer();
+//        try {
+//            for (Metadata metadata : buffer) {
+//                if (metadata == null) continue;
+//                return metadata.getDriveId();
+//            }
+//        } finally {
+//            buffer.close();
+//        }
         return null;
     }
 
     private Status createFile(DriveFolder folder, String fileName, byte[] bytes) throws IOException {
-        MetadataChangeSet changeSet = new MetadataChangeSet.Builder()
-                .setTitle(fileName)
-                .setMimeType(Export.BACKUP_MIME_TYPE).build();
-        // Create a file in the root folder
-        DriveApi.DriveContentsResult contentsResult = Drive.DriveApi.newDriveContents(googleApiClient).await();
-        Status contentsResultStatus = contentsResult.getStatus();
-        if (contentsResultStatus.isSuccess()) {
-            DriveContents contents = contentsResult.getDriveContents();
-            contents.getOutputStream().write(bytes);
-            DriveFolder.DriveFileResult fileResult = folder.createFile(googleApiClient, changeSet, contents).await();
-            return fileResult.getStatus();
-        } else {
-            return contentsResultStatus;
-        }
+//        MetadataChangeSet changeSet = new MetadataChangeSet.Builder()
+//                .setTitle(fileName)
+//                .setMimeType(Export.BACKUP_MIME_TYPE).build();
+//        // Create a file in the root folder
+//        DriveApi.DriveContentsResult contentsResult = Drive.DriveApi.newDriveContents(googleApiClient).await();
+//        Status contentsResultStatus = contentsResult.getStatus();
+//        if (contentsResultStatus.isSuccess()) {
+//            DriveContents contents = contentsResult.getDriveContents();
+//            contents.getOutputStream().write(bytes);
+//            DriveFolder.DriveFileResult fileResult = folder.createFile(googleApiClient, changeSet, contents).await();
+//            return fileResult.getStatus();
+//        } else {
+//            return contentsResultStatus;
+//        }
+        throw new IOException(String.valueOf(R.string.google_drive_disabled));
+
     }
 
     private void handleConnectionResult(ConnectionResult connectionResult) {
@@ -294,18 +311,20 @@ public class GoogleDriveClient {
 
     public void uploadFile(File file) throws ImportExportException {
         try {
-            String targetFolder = getDriveFolderName();
-            ConnectionResult connectionResult = connect();
-            if (connectionResult.isSuccess()) {
-                DriveFolder folder = getDriveFolder(targetFolder);
-                InputStream is = new FileInputStream(file);
-                try {
-                    byte[] bytes = IOUtils.toByteArray(is);
-                    createFile(folder, file.getName(), bytes);
-                } finally {
-                    IOUtil.closeInput(is);
-                }
-            }
+//            String targetFolder = getDriveFolderName();
+//            ConnectionResult connectionResult = connect();
+//            if (connectionResult.isSuccess()) {
+//                DriveFolder folder = getDriveFolder(targetFolder);
+//                InputStream is = new FileInputStream(file);
+//                try {
+//                    byte[] bytes = IOUtils.toByteArray(is);
+//                    createFile(folder, file.getName(), bytes);
+//                } finally {
+//                    IOUtil.closeInput(is);
+//                }
+//            }
+            throw new ImportExportException(R.string.google_drive_disabled);
+
         } catch (Exception e) {
             throw new ImportExportException(R.string.google_drive_connection_failed, e);
         }

--- a/app/src/main/java/ru/orangesoftware/financisto/export/dropbox/DropboxBackupTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/dropbox/DropboxBackupTask.java
@@ -11,6 +11,8 @@ package ru.orangesoftware.financisto.export.dropbox;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.net.Uri;
+
 import ru.orangesoftware.financisto.activity.MainActivity;
 import ru.orangesoftware.financisto.backup.DatabaseExport;
 import ru.orangesoftware.financisto.db.DatabaseAdapter;
@@ -28,7 +30,7 @@ public class DropboxBackupTask extends ImportExportAsyncTask {
     }
 
     @Override
-    protected Object work(Context context, DatabaseAdapter db, String... params) throws Exception {
+    protected Object work(Context context, DatabaseAdapter db, Uri... params) throws Exception {
         DatabaseExport export = new DatabaseExport(context, db.db(), true);
         String backupFileName = export.export();
         doForceUploadToDropbox(context, backupFileName);

--- a/app/src/main/java/ru/orangesoftware/financisto/export/dropbox/DropboxListFilesTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/dropbox/DropboxListFilesTask.java
@@ -11,6 +11,7 @@ package ru.orangesoftware.financisto.export.dropbox;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.net.Uri;
 
 import ru.orangesoftware.financisto.R;
 import ru.orangesoftware.financisto.activity.MenuListItem;
@@ -43,7 +44,7 @@ public class DropboxListFilesTask extends ImportExportAsyncTask {
     }
 
     @Override
-    protected Object work(Context context, DatabaseAdapter db, String... params) throws Exception {
+    protected Object work(Context context, DatabaseAdapter db, Uri... params) throws Exception {
         try {
             Dropbox dropbox = new Dropbox(context);
             List<String> files = dropbox.listFiles();

--- a/app/src/main/java/ru/orangesoftware/financisto/export/dropbox/DropboxRestoreTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/dropbox/DropboxRestoreTask.java
@@ -11,6 +11,8 @@ package ru.orangesoftware.financisto.export.dropbox;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.net.Uri;
+
 import ru.orangesoftware.financisto.R;
 import ru.orangesoftware.financisto.activity.MainActivity;
 import ru.orangesoftware.financisto.backup.DatabaseImport;
@@ -33,7 +35,7 @@ public class DropboxRestoreTask extends ImportExportAsyncTask {
     }
 
     @Override
-    protected Object work(Context context, DatabaseAdapter db, String... params) throws Exception {
+    protected Object work(Context context, DatabaseAdapter db, Uri... params) throws Exception {
         Dropbox dropbox = new Dropbox(context);
         DatabaseImport.createFromDropboxBackup(context, db, dropbox, backupFile).importDatabase();
         return true;

--- a/app/src/main/java/ru/orangesoftware/financisto/export/qif/QifExportTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/qif/QifExportTask.java
@@ -3,6 +3,8 @@ package ru.orangesoftware.financisto.export.qif;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.net.Uri;
+
 import ru.orangesoftware.financisto.db.DatabaseAdapter;
 import ru.orangesoftware.financisto.export.ImportExportAsyncTask;
 
@@ -16,7 +18,7 @@ public class QifExportTask extends ImportExportAsyncTask {
 	}
 	
 	@Override
-	protected Object work(Context context, DatabaseAdapter db, String...params) throws Exception {
+	protected Object work(Context context, DatabaseAdapter db, Uri...params) throws Exception {
         QifExport qifExport = new QifExport(context, db, options);
         String backupFileName = qifExport.export();
         if (options.uploadToDropbox) {

--- a/app/src/main/java/ru/orangesoftware/financisto/export/qif/QifImportTask.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/export/qif/QifImportTask.java
@@ -11,6 +11,7 @@ package ru.orangesoftware.financisto.export.qif;
 import android.app.Activity;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.net.Uri;
 import android.os.Handler;
 import android.util.Log;
 
@@ -36,7 +37,7 @@ public class QifImportTask extends ImportExportAsyncTask {
     }
 
     @Override
-    protected Object work(Context context, DatabaseAdapter db, String... params) throws Exception {
+    protected Object work(Context context, DatabaseAdapter db, Uri... params) throws Exception {
         try {
             QifImport qifImport = new QifImport(context, db, options);
             qifImport.importDatabase();

--- a/app/src/main/java/ru/orangesoftware/financisto/service/RecurrenceScheduler.java
+++ b/app/src/main/java/ru/orangesoftware/financisto/service/RecurrenceScheduler.java
@@ -1,5 +1,6 @@
 package ru.orangesoftware.financisto.service;
 
+import android.annotation.SuppressLint;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -165,6 +166,7 @@ public class RecurrenceScheduler {
         return scheduled;
     }
 
+    @SuppressLint("ObsoleteSdkInt")
     public boolean scheduleAlarm(Context context, TransactionInfo transaction, long now) {
         if (shouldSchedule(transaction, now)) {
             Date scheduleTime = transaction.nextDateTime;
@@ -208,7 +210,8 @@ public class RecurrenceScheduler {
         Intent intent = new Intent("ru.orangesoftware.financisto.SCHEDULED_ALARM");
         intent.setClass(context, ScheduledAlarmReceiver.class);
         intent.putExtra(SCHEDULED_TRANSACTION_ID, transactionId);
-        return PendingIntent.getBroadcast(context, (int)transactionId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getBroadcast(context, (int)transactionId, intent,
+                PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     /**

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -877,6 +877,7 @@
     <string name="google_drive_permission_required">Please authorize Financisto to access your Google Drive then try again…</string>
     <string name="google_drive_loading_files">Loading files from Google Drive…</string>
     <string name="google_drive_account_required">Please specify your Google Drive account in the Preferences then try again…</string>
+    <string name="google_drive_disabled">shk:Google drive sync is temporarily disabled…</string>
     <string name="google_drive_backup_success">Backup success on Google Drive: %s</string>
     <string name="google_drive_restore_in_progress">Restoring database from Google Drive…</string>
     <string name="google_drive_connection_resolved">Connection resolved. Please try the last operation again…</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -151,7 +151,7 @@
     </style>
 
     <style name="BottomBarButton">
-<!--        <item name="android:background">>@color/holo_gray_dark</item>-->
+        <item name="android:background">@android:color/transparent</item>
         <item name="android:layout_width">@dimen/action_button_size</item>
         <item name="android:layout_height">@dimen/action_button_size</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -151,7 +151,7 @@
     </style>
 
     <style name="BottomBarButton">
-        <item name="android:background"></item>
+<!--        <item name="android:background">>@color/holo_gray_dark</item>-->
         <item name="android:layout_width">@dimen/action_button_size</item>
         <item name="android:layout_height">@dimen/action_button_size</item>
     </style>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -3,4 +3,5 @@
     <external-path name="financisto" path="financisto" />
     <external-path name="financisto_pictures" path="financisto/pictures" />
     <external-path name="pictures" path="Pictures" />
+    <files-path name="my_files" path="." />
 </paths>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:4.2.2'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # The setting is particularly useful for tweaking memory settings.
 android.enableJetifier=true
 android.useAndroidX=true
-android.enableSeparateAnnotationProcessing=true
+#android.enableSeparateAnnotationProcessing=true
 
 org.gradle.jvmargs=-Xmx2000m
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Nov 13 12:45:34 AEDT 2019
+#Tue Mar 14 18:33:56 IST 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
SDK-33 compatibility in financisto is completely broken. from manifest to permissions to alarms, scheduling etc. The PR contains the bare-minimum fixes to make it work under Android 13. Many functionalities like automated backup, google-drive/dropbox syncs, biometric lock/unlock and on-screen widget are still broken. This bare-minimum fix contains following highlights - 
- manifest fixes 
- gradle version upgrades
- compile and target sdk changed to 33 
- fix permissions: asks and run time requests 
- overhaul the backup/restore framework entirely to work without dipping into permissions 
- fix bottom buttons to gel in well with the theme
- manual backup/restore functionality working perfectly fine with new permissions and security setup in android sdk-33